### PR TITLE
Revert "Quick fix to make arrow inline-block"

### DIFF
--- a/docs/lib/css/z-index.css
+++ b/docs/lib/css/z-index.css
@@ -146,7 +146,3 @@ html, body, #app {
   border-bottom: 1px solid var(--cell-border-color);
   flex: 0;
 }
-
-.arrow {
-  display: inline-block;
-}


### PR DESCRIPTION
Reverts gregtatum/z-index-devtool#63

Oops. Turns out my `npm start` was using old resources and didn't update properly, so I was looking at an old version of the project and fixed something that didn't need to be fixed.