### PR TITLE
Element Picker Implementation

### DIFF
--- a/docs/examples/z-index-onclick.html
+++ b/docs/examples/z-index-onclick.html
@@ -62,7 +62,7 @@
     z-index: -5;</code>
 </div>
 <div id="div3">
-  <div id="divclick" onclick="console.log('click test')">
+  <div id="divclick" onclick="alert('onClick Registered')">
     <span><strong>Clickable Division Element #5</strong></span>
     <code>position: relative;<br/>
       z-index: 1;</code>

--- a/src/components/dom-container.js
+++ b/src/components/dom-container.js
@@ -1,7 +1,7 @@
 const {DOM, createClass} = require("react");
 const {div} = DOM;
 const React = require("react");
-const {computeBoundingRect} = require("../actions/stacking-context");
+const {expandNode, selectStackingContextNode, computeBoundingRect} = require("../actions/stacking-context");
 
 /**
  * Container for the DOM. Takes in a single <div> element and displays it.
@@ -23,10 +23,38 @@ const DomContainer = createClass({
       dangerouslySetInnerHTML: {__html: text},
       onScroll: () => {
         store.dispatch(computeBoundingRect(store.getState().stackingContext.selElt))
+      },
+      onClick: (event) => {
+        event.persist();
+        let element = document.elementFromPoint(event.clientX, event.clientY);
+        let tree = store.getState().stackingContext.tree;
+        let node = getTreeObject(element, tree);
+        console.log(node);
+        if (node) {
+          store.dispatch(selectStackingContextNode(node));
+          let parent = node.parentStackingContext;
+          while (parent) {
+            store.dispatch(expandNode(parent));
+            parent = parent.parentStackingContext;
+          }
+        }
       }
     });
   }
 });
+
+function getTreeObject(el, tree) {
+  let nodeObject;
+  for (let child of tree) {
+    if (child.el === el) {
+      nodeObject = child;
+    }
+    else if (nodeObject === undefined && child.stackingContextChildren) {
+      nodeObject = getTreeObject(el, child.stackingContextChildren);
+    }
+  }
+  return nodeObject;
+}
 
 DomContainer.contextTypes = {
   store: React.PropTypes.object

--- a/src/components/dom-container.js
+++ b/src/components/dom-container.js
@@ -29,7 +29,6 @@ const DomContainer = createClass({
         let element = document.elementFromPoint(event.clientX, event.clientY);
         let tree = store.getState().stackingContext.tree;
         let node = getTreeObject(element, tree);
-        console.log(node);
         if (node) {
           store.dispatch(selectStackingContextNode(node));
           let parent = node.parentStackingContext;

--- a/src/stacking-context/index.js
+++ b/src/stacking-context/index.js
@@ -16,6 +16,9 @@
  * - specifying any attribute above in will-change even if you don't specify values for these attributes directly
  * - elements with -webkit-overflow-scrolling set to "touch"
  */
+
+const INCLUDE_HTML_TAGS = ["DIV", "SPAN", "STRONG", "IMG", "TITLE"];
+
 function getWin(el) {
   return el.ownerDocument.defaultView;
 }
@@ -82,7 +85,7 @@ function getStackingContextTree(root, treeNodes = [], parentElement) {
     let newNode;
     // Filter for divs and spans only.
     // Easily change to include others. (Maybe make it a configurable setting in the future)
-    if (child.tagName === "DIV" || child.tagName === "SPAN") {
+    if (INCLUDE_HTML_TAGS.indexOf(child.tagName) !== -1) {
       let stackingContextProperties = getStackingContextProperties(child);
       // Terminology: parentElement = parent element of the current element
       //              parentStackingContext = the parent stacking order element


### PR DESCRIPTION
Implementation of selecting an element in the dom and having it highlight and display in the context tree.

** NOTE: So I implemented a INCLUDE_HTML_TAGS const in the stacking-context/index.js which will list which element types get added to the stacking context. However, in our HTML examples, we have `<span><strong>text</strong></span>` which makes the stacking context have a span node and a strong node (but they are visually the same thing). I don't know how to squish span and strong into one node (or if I even should) (or if its even possible to differentiate a case where the span has its own properties)